### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Menu, X } from 'lucide-react';
+import ThemeToggle from './ThemeToggle';
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -69,7 +70,7 @@ const Navbar = () => {
             <span className="font-bold text-xl animated-gradient-text">AuraByt</span>
           </Link>
 
-          <nav className="hidden md:flex space-x-8">
+          <nav className="hidden md:flex space-x-8 items-center">
             {navLinks.map((link) => (
               <Link
                 key={link.name}
@@ -83,6 +84,7 @@ const Navbar = () => {
                 {link.name}
               </Link>
             ))}
+            <ThemeToggle />
           </nav>
 
           <button
@@ -116,6 +118,7 @@ const Navbar = () => {
                   {link.name}
                 </Link>
               ))}
+              <ThemeToggle />
             </nav>
           </div>
         )}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+
+const ThemeToggle = () => {
+  const [theme, setTheme] = useState<string>(() => {
+    if (typeof localStorage !== "undefined") {
+      return localStorage.getItem("theme") || "light";
+    }
+    return "light";
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  return (
+    <button
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className="p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      aria-label="Toggle theme"
+    >
+      {theme === "dark" ? <Sun size={20} /> : <Moon size={20} />}
+    </button>
+  );
+};
+
+export default ThemeToggle;


### PR DESCRIPTION
## Summary
- add simple ThemeToggle component using localStorage
- show ThemeToggle in Navbar for desktop and mobile

## Testing
- `npm run lint` *(fails: cannot pass due to lint errors)*
- `npm run typecheck`
- `npm run build` *(fails: swc plugin error)*

------
https://chatgpt.com/codex/tasks/task_e_68409efc90e08331b52065fee946ddc8