### PR TITLE
Fix hero typewriter visibility on mobile

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -8,6 +8,7 @@ const Hero = () => {
   const [isAnimating, setIsAnimating] = useState(false);
   const textRef = useRef<HTMLSpanElement>(null);
   const heroRef = useRef<HTMLElement>(null);
+  const firstRender = useRef(true);
 
   useEffect(() => {
     // Set up text rotation interval
@@ -28,7 +29,11 @@ const Hero = () => {
   useEffect(() => {
     const chars = textRef.current?.querySelectorAll('.char');
     if (chars) {
-      chars.forEach((char) => char.classList.remove('visible'));
+      if (!firstRender.current) {
+        chars.forEach((char) => char.classList.remove('visible'));
+      } else {
+        firstRender.current = false;
+      }
       chars.forEach((char, i) => {
         setTimeout(() => char.classList.add('visible'), 50 * i);
       });
@@ -96,7 +101,7 @@ const Hero = () => {
                     className="inline-block"
                   >
                     {businessTexts[currentTextIndex].split('').map((char, i) => (
-                      <span key={i} className="char inline-block transition-all duration-300 transform">{char}</span>
+                      <span key={i} className="char visible inline-block transition-all duration-300 transform">{char}</span>
                     ))}
                   </span>
                 </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -70,6 +70,15 @@
     animation: gradient 8s ease infinite;
   }
 
+  /* Characters used in typewriter animations */
+  .char {
+    @apply opacity-0 translate-y-1 transition-all duration-300;
+  }
+
+  .char.visible {
+    @apply opacity-100 translate-y-0;
+  }
+
   .btn-primary {
     @apply px-4 py-2 sm:px-6 sm:py-3 md:px-8 md:py-4 bg-primary text-primary-foreground font-semibold rounded-lg 
            hover:bg-primary/90 transition-all duration-300 


### PR DESCRIPTION
## Summary
- keep characters visible by default and skip removal on first render
- ensure sequential animation still runs after text change

## Testing
- `npm run build`
- `npm run lint` *(fails: multiple errors unrelated to hero)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6845df06e9b4833195f3aaea214f28cd