### PR TITLE
Fix hero text and simplify navbar

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useLayoutEffect } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { HoverButton } from '@/components/ui/hover-glow-button';
 
@@ -23,6 +23,15 @@ const Hero = () => {
       clearInterval(interval);
     };
   }, [businessTexts.length]);
+
+  useLayoutEffect(() => {
+    const chars = textRef.current?.querySelectorAll('.char');
+    if (chars) {
+      chars.forEach((char, i) => {
+        setTimeout(() => char.classList.add('visible'), 50 * i);
+      });
+    }
+  }, []);
 
   // Update character animations whenever the current text changes
   useEffect(() => {
@@ -96,7 +105,7 @@ const Hero = () => {
                     className="inline-block"
                   >
                     {businessTexts[currentTextIndex].split('').map((char, i) => (
-                      <span key={i} className="char inline-block transition-all duration-300 transform">{char}</span>
+                      <span key={i} className="char visible inline-block transition-all duration-300 transform">{char}</span>
                     ))}
                   </span>
                 </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,20 +1,16 @@
 
 import React, { useState, useEffect, useRef } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Menu, X, ChevronDown, Code, BarChart3, Headphones } from 'lucide-react';
+import { Link, useLocation } from 'react-router-dom';
+import { Menu, X } from 'lucide-react';
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
-  const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
   const location = useLocation();
-  const navigate = useNavigate();
   const navbarRef = useRef<HTMLElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setIsOpen(false);
-    setActiveDropdown(null);
   }, [location.pathname]);
 
   useEffect(() => {
@@ -25,63 +21,20 @@ const Navbar = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setActiveDropdown(null);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  const handleServiceNavigation = () => {
-    setIsOpen(false);
-    setActiveDropdown(null);
-    navigate('/services');
-  };
 
   const navLinks = [
     { name: 'Home', path: '/' },
-    { 
-      name: 'Services', 
-      path: '/services',
-      dropdown: [
-        { 
-          name: 'Software Development', 
-          icon: <Code size={16} />,
-          description: 'Custom web applications & enterprise software'
-        },
-        { 
-          name: 'Digital Marketing', 
-          icon: <BarChart3 size={16} />,
-          description: 'SEO, social media & growth strategies'
-        },
-        { 
-          name: 'IT Infrastructure', 
-          icon: <Headphones size={16} />,
-          description: 'Cloud solutions & technical support'
-        }
-      ]
-    },
+    { name: 'Services', path: '/services' },
     { name: 'About', path: '/about' },
     { name: 'Contact', path: '/contact' },
   ];
 
-  const handleDropdownToggle = (linkName: string) => {
-    setActiveDropdown(activeDropdown === linkName ? null : linkName);
-  };
-
   const handleLinkClick = () => {
     setIsOpen(false);
-    setActiveDropdown(null);
   };
 
   const handleMobileMenuToggle = () => {
     setIsOpen(!isOpen);
-    setActiveDropdown(null);
   };
 
   return (
@@ -119,74 +72,16 @@ const Navbar = () => {
           {/* Desktop Navigation */}
           <nav className="hidden lg:flex items-center space-x-2">
             {navLinks.map((link) => (
-              <div key={link.name} className="relative" ref={link.dropdown ? dropdownRef : undefined}>
-                {link.dropdown ? (
-                  <div className="relative">
-                    <div className="flex items-center">
-                      <Link
-                        to={link.path}
-                        onClick={handleLinkClick}
-                        className={`flex items-center px-6 py-3 text-sm font-medium transition-all duration-300 rounded-lg hover:bg-primary/10 hover:text-primary relative group ${
-                          location.pathname === link.path || location.pathname.startsWith('/services')
-                            ? 'text-primary bg-primary/10'
-                            : 'text-foreground hover:text-primary'
-                        }`}
-                      >
-                        {link.name}
-                      </Link>
-                      <button
-                        onClick={() => handleDropdownToggle(link.name)}
-                        className="ml-1 p-1 rounded hover:bg-primary/10 transition-colors duration-200"
-                        aria-label="Toggle services menu"
-                      >
-                        <ChevronDown
-                          size={16}
-                          className={`transition-transform duration-300 ${
-                            activeDropdown === link.name ? 'rotate-180' : ''
-                          }`}
-                        />
-                      </button>
-                    </div>
-                    
-                    {/* Desktop Dropdown Menu */}
-                    {activeDropdown === link.name && (
-                      <div className="absolute top-full left-0 mt-3 w-80 bg-card/98 backdrop-blur-xl rounded-lg shadow-2xl border border-border py-3 animate-in fade-in-0 zoom-in-95 duration-200 z-50">
-                        {link.dropdown.map((item) => (
-                          <button
-                            key={item.name}
-                            onClick={handleServiceNavigation}
-                            className="flex items-start px-4 py-4 text-sm hover:bg-primary/10 transition-all duration-200 mx-2 rounded-lg group w-full text-left"
-                          >
-                            <div className="flex-shrink-0 w-8 h-8 bg-primary/10 rounded-lg flex items-center justify-center mr-3 group-hover:bg-primary/20 transition-colors duration-200">
-                              <span className="text-primary">{item.icon}</span>
-                            </div>
-                            <div>
-                              <div className="font-medium text-foreground group-hover:text-primary transition-colors duration-200">
-                                {item.name}
-                              </div>
-                              <div className="text-xs text-muted-foreground mt-1 leading-relaxed">
-                                {item.description}
-                              </div>
-                            </div>
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  <Link
-                    to={link.path}
-                    className={`px-6 py-3 text-sm font-medium transition-all duration-300 rounded-lg hover:bg-primary/10 hover:text-primary relative group ${
-                      location.pathname === link.path
-                        ? 'text-primary bg-primary/10'
-                        : 'text-foreground hover:text-primary'
-                    }`}
-                    onClick={handleLinkClick}
-                  >
-                    {link.name}
-                  </Link>
-                )}
-              </div>
+              <Link
+                key={link.name}
+                to={link.path}
+                className={`px-6 py-3 text-sm font-medium transition-all duration-300 rounded-lg hover:bg-primary/10 hover:text-primary relative group ${
+                  location.pathname === link.path ? 'text-primary bg-primary/10' : 'text-foreground hover:text-primary'
+                }`}
+                onClick={handleLinkClick}
+              >
+                {link.name}
+              </Link>
             ))}
           </nav>
 
@@ -206,64 +101,19 @@ const Navbar = () => {
           <div className="lg:hidden pb-4 animate-in slide-in-from-top-2 duration-300 relative z-40">
             <div className="bg-card/98 backdrop-blur-xl rounded-lg shadow-2xl border border-border p-3 sm:p-4 space-y-1 sm:space-y-2 mt-2">
               {navLinks.map((link, idx) => (
-                <div key={link.name}>
-                  {link.dropdown ? (
-                    <div>
-                      <div className="w-full flex items-center justify-between">
-                        <Link
-                          to={link.path}
-                          className={`flex-grow px-3 sm:px-4 py-3 text-sm font-medium transition-all duration-300 rounded-lg ${
-                            location.pathname === link.path || location.pathname.startsWith('/services')
-                              ? 'text-primary bg-primary/10'
-                              : 'text-foreground hover:text-primary hover:bg-primary/5'
-                          }`}
-                          onClick={handleLinkClick}
-                        >
-                          {link.name}
-                        </Link>
-                        <button
-                          onClick={() => handleDropdownToggle(link.name)}
-                          className="p-2 rounded-lg hover:bg-primary/10 transition-colors duration-200"
-                          aria-label="Toggle services menu"
-                        >
-                          <ChevronDown
-                            size={16}
-                            className={`transition-transform duration-300 ${
-                              activeDropdown === link.name ? 'rotate-180' : ''
-                            }`}
-                          />
-                        </button>
-                      </div>
-                      {activeDropdown === link.name && (
-                        <div className="mt-2 ml-2 sm:ml-4 space-y-1 animate-in slide-in-from-top-1 duration-200">
-                          {link.dropdown.map((item) => (
-                            <button
-                              key={item.name}
-                              onClick={handleServiceNavigation}
-                              className="flex items-center px-3 sm:px-4 py-3 text-sm text-muted-foreground hover:text-primary hover:bg-primary/5 transition-all duration-200 rounded-lg w-full text-left"
-                            >
-                              <span className="mr-2 sm:mr-3 text-primary flex-shrink-0">{item.icon}</span>
-                              <span className="text-xs sm:text-sm">{item.name}</span>
-                            </button>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  ) : (
-                    <Link
-                      to={link.path}
-                      className={`block px-3 sm:px-4 py-3 text-sm font-medium transition-all duration-300 rounded-lg ${
-                        location.pathname === link.path
-                          ? 'text-primary bg-primary/10'
-                          : 'text-foreground hover:text-primary hover:bg-primary/5'
-                      }`}
-                      style={{ animationDelay: `${idx * 50}ms` }}
-                      onClick={handleLinkClick}
-                    >
-                      {link.name}
-                    </Link>
-                  )}
-                </div>
+                <Link
+                  key={link.name}
+                  to={link.path}
+                  className={`block px-3 sm:px-4 py-3 text-sm font-medium transition-all duration-300 rounded-lg ${
+                    location.pathname === link.path
+                      ? 'text-primary bg-primary/10'
+                      : 'text-foreground hover:text-primary hover:bg-primary/5'
+                  }`}
+                  style={{ animationDelay: `${idx * 50}ms` }}
+                  onClick={handleLinkClick}
+                >
+                  {link.name}
+                </Link>
               ))}
             </div>
           </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -68,6 +68,16 @@
   .gradient-text {
     @apply bg-clip-text text-transparent bg-gradient-to-r from-primary via-blue-400 to-primary bg-[length:200%_auto];
     animation: gradient 8s ease infinite;
+    -webkit-text-fill-color: transparent;
+  }
+
+  /* Characters used in typewriter animations */
+  .char {
+    @apply opacity-0 translate-y-1 transition-all duration-300;
+  }
+
+  .char.visible {
+    @apply opacity-100 translate-y-0;
   }
 
   .btn-primary {


### PR DESCRIPTION
## Summary
- ensure hero typewriter characters become visible on mount
- remove the unused services dropdown from the navbar
- add `-webkit-text-fill-color: transparent` to gradient text so mobile Safari renders it correctly

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: cannot find `@eslint/js`)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845df06e9b4833195f3aaea214f28cd